### PR TITLE
```

### DIFF
--- a/app/Domain/Board/Listeners/CreateDefaultBoard.php
+++ b/app/Domain/Board/Listeners/CreateDefaultBoard.php
@@ -1,10 +1,12 @@
 <?php
 
-declare(strict_types=1);
-
 namespace App\Domain\Board\Listeners;
 
+
 use App\Domain\Board\Models\Board;
+use App\Domain\Project\Events\CreatedProjectEvent;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class CreateDefaultBoard
 {
@@ -19,13 +21,13 @@ class CreateDefaultBoard
     /**
      * Handle the event.
      */
-    public function handle(\App\Domain\Board\Events\CreateDefaultBoard $event): void
+    public function handle(CreatedProjectEvent $event): void
     {
-        $project = $event->project;
+        $projectId = $event->projectId;
         $boards = ['Backlog', 'To Do', 'In Progress', 'Review', 'Done'];
         foreach ($boards as $board) {
             Board::create([
-                'project_id' => $project->id,
+                'project_id' => $projectId,
                 'name' => $board,
             ]);
         }

--- a/app/Domain/Board/Listeners/DeleteBoardByProject.php
+++ b/app/Domain/Board/Listeners/DeleteBoardByProject.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Domain\Board\Listeners;
+
+use App\Domain\Board\Models\Board;
+use App\Domain\Project\Events\DeletedProject;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class DeleteBoardByProject
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(DeletedProject $event): void
+    {
+        Board::query()->where('project_id', $event->projectId)->delete();
+    }
+}

--- a/app/Domain/Project/Events/CreatedProjectEvent.php
+++ b/app/Domain/Project/Events/CreatedProjectEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Domain\Project\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CreatedProjectEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public readonly int $projectId)
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Domain/Project/Events/DeletedProject.php
+++ b/app/Domain/Project/Events/DeletedProject.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Domain\Project\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DeletedProject
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public readonly int $projectId)
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Domain/Project/Observers/ProjectObserver.php
+++ b/app/Domain/Project/Observers/ProjectObserver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Domain\Project\Observers;
 
+use App\Domain\Project\Events\CreatedProjectEvent;
+use App\Domain\Project\Events\DeletedProject;
 use App\Domain\Project\Models\Project;
 
 class ProjectObserver
@@ -15,6 +17,8 @@ class ProjectObserver
     {
         $project->project_code = 'PJR-'.$project->id;
         $project->save();
+
+        event(new CreatedProjectEvent($project->id));
     }
 
     /**
@@ -30,7 +34,7 @@ class ProjectObserver
      */
     public function deleted(Project $project): void
     {
-        //
+        event(new DeletedProject($project->id));
     }
 
     /**

--- a/app/Events/CreatedProjectEvent.php
+++ b/app/Events/CreatedProjectEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CreatedProjectEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Livewire/Projects/Project.php
+++ b/app/Livewire/Projects/Project.php
@@ -54,12 +54,7 @@ class Project extends Component
     {
         $project = $this->projectForm->store();
         $this->projectForm->reset();
-        /**
-         * @todo criar um novo Event, CreatedProject
-         *    -> Listener de Board
-         *    -> Listener de Sprint
-         */
-        event(new CreateDefaultBoard($project));
+
         Flux::toast(text: 'Projeto criado com sucesso!', heading: 'Sucesso', variant: 'success');
 
         return $this->redirect(route('projects.index'), navigate: true);
@@ -89,7 +84,7 @@ class Project extends Component
         Flux::toast(text: 'Projeto deletado com sucesso!', heading: 'Sucesso', variant: 'success');
         $this->projectId = 0;
 
-        /** @todo Create a event and listener to delete boards,sprints and tasks */
+
         return $this->redirect(route('projects.index'), navigate: true);
     }
 


### PR DESCRIPTION
Refactor project event handling for board creation/deletion

Replaced ad-hoc event triggers with domain-specific events `CreatedProjectEvent` and `DeletedProject`. Refactored the `CreateDefaultBoard` and introduced `DeleteBoardByProject` listeners for improved decoupling and maintainability. Updated relevant areas to utilize the new event-driven architecture.
```